### PR TITLE
Make vizkit dependendcy optional

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -16,7 +16,7 @@
 	<depend package="base/orogen/types" />
 	<depend package="base/logging" />
 	<depend package="tools/orocos.rb" />
-	<depend package="gui/vizkit" />
+	<depend package="gui/vizkit" optional="1" />
 	
 	<depend package="slam/orogen/maps" />
 	<depend package="slam/orogen/pcl" />


### PR DESCRIPTION
Only the scripts require vizkit, and those don't get installed