### PR TITLE
only allow a single thread running at a time for map building

### DIFF
--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -3,7 +3,8 @@ add_library(${SLAM3D_TASKLIB_NAME} SHARED
     ${SLAM3D_TASKLIB_SOURCES}
     BaseLogger.cpp
     RockOdometry.cpp
-    Common.cpp)
+    Common.cpp
+    ThreadedFunctionQueue.cpp)
 
 add_dependencies(${SLAM3D_TASKLIB_NAME}
     regen-typekit)
@@ -26,5 +27,6 @@ FILES
     BaseLogger.hpp
     RockOdometry.hpp
     Common.hpp
+    ThreadedFunctionQueue.hpp
 DESTINATION
     include/orocos/slam3d)

--- a/tasks/PointcloudMapper.cpp
+++ b/tasks/PointcloudMapper.cpp
@@ -55,7 +55,7 @@ bool PointcloudMapper::generate_cloud()
 	mLogger->message(INFO, "Requested pointcloud generation.");
 	VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
 	std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
-	mapThread.addFunctionCall(task, true);
+	pointcloudThread.addFunctionCall(task, true);
 	return true;
 }
 
@@ -64,7 +64,6 @@ bool PointcloudMapper::generate_map()
 	mLogger->message(INFO, "Requested map generation.");
 	if(mGraph->optimized())
 	{
-		mLogger->message(INFO, "Running map generation.");
 		VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
 		std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
 		mapThread.addFunctionCall(task, true);

--- a/tasks/PointcloudMapper.cpp
+++ b/tasks/PointcloudMapper.cpp
@@ -55,7 +55,8 @@ bool PointcloudMapper::generate_cloud()
 	mLogger->message(INFO, "Requested pointcloud generation.");
 	cloudThread.join();
 	VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
-	cloudThread = boost::thread(&PointcloudMapper::sendPointcloud, this, vertices);
+	MappingThread::MappingTask task(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
+	mapThread.addTask(task, true);
 	return true;
 }
 
@@ -67,7 +68,8 @@ bool PointcloudMapper::generate_map()
 	{
 		mLogger->message(INFO, "Running map generation.");
 		VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
-		mapThread = boost::thread(&PointcloudMapper::rebuildMap, this, vertices);
+		MappingThread::MappingTask task(std::bind(&PointcloudMapper::rebuildMap, this, std::placeholders::_1), vertices);
+		mapThread.addTask(task, true);
 	}else
 	{
 		sendMap();

--- a/tasks/PointcloudMapper.cpp
+++ b/tasks/PointcloudMapper.cpp
@@ -65,7 +65,7 @@ bool PointcloudMapper::generate_map()
 	if(mGraph->optimized())
 	{
 		VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
-		std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
+		std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::rebuildMap, this, std::placeholders::_1), vertices);
 		mapThread.addFunctionCall(task, true);
 	}else
 	{

--- a/tasks/PointcloudMapper.cpp
+++ b/tasks/PointcloudMapper.cpp
@@ -53,7 +53,6 @@ bool PointcloudMapper::generate_cloud()
 {
 	// Publish accumulated cloud
 	mLogger->message(INFO, "Requested pointcloud generation.");
-	cloudThread.join();
 	VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
 	std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
 	mapThread.addFunctionCall(task, true);
@@ -63,7 +62,6 @@ bool PointcloudMapper::generate_cloud()
 bool PointcloudMapper::generate_map()
 {
 	mLogger->message(INFO, "Requested map generation.");
-	mapThread.join();
 	if(mGraph->optimized())
 	{
 		mLogger->message(INFO, "Running map generation.");

--- a/tasks/PointcloudMapper.cpp
+++ b/tasks/PointcloudMapper.cpp
@@ -55,8 +55,8 @@ bool PointcloudMapper::generate_cloud()
 	mLogger->message(INFO, "Requested pointcloud generation.");
 	cloudThread.join();
 	VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
-	MappingThread::MappingTask task(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
-	mapThread.addTask(task, true);
+	std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
+	mapThread.addFunctionCall(task, true);
 	return true;
 }
 
@@ -68,8 +68,8 @@ bool PointcloudMapper::generate_map()
 	{
 		mLogger->message(INFO, "Running map generation.");
 		VertexObjectList vertices = mGraph->getVerticesFromSensor(mPclSensor->getName());
-		MappingThread::MappingTask task(std::bind(&PointcloudMapper::rebuildMap, this, std::placeholders::_1), vertices);
-		mapThread.addTask(task, true);
+		std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
+		mapThread.addFunctionCall(task, true);
 	}else
 	{
 		sendMap();

--- a/tasks/PointcloudMapper.hpp
+++ b/tasks/PointcloudMapper.hpp
@@ -8,7 +8,6 @@
 #include <maps/grid/MLSMap.hpp>
 
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/thread.hpp>
 
 #include "GridConfiguration.hpp"
 #include "ThreadedFunctionQueue.hpp"

--- a/tasks/PointcloudMapper.hpp
+++ b/tasks/PointcloudMapper.hpp
@@ -7,20 +7,101 @@
 
 #include <maps/grid/MLSMap.hpp>
 
-#include <queue>
+#include <deque>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread.hpp>
+
+#include <thread>
+#include <functional>
+#include <future>
 
 #include "GridConfiguration.hpp"
 
 namespace slam3d
 {	
 	class RockOdometry;
-	
+
 	class PointcloudMapper : public PointcloudMapperBase
 	{
 	friend class PointcloudMapperBase;
 	protected:
+
+
+		class MappingThread {
+		 public:
+			struct MappingTask {
+				MappingTask(){};
+				MappingTask(std::function<void(VertexObjectList vertices)> function, VertexObjectList vertices ):function(function),vertices(vertices) {}
+				std::function<void(VertexObjectList vertices)> function;
+				VertexObjectList vertices;
+			};
+
+			MappingThread(size_t maxQueueSize = 1):maxQueueSize(maxQueueSize) {
+				thread = std::thread([&](){
+					bool run = true;
+					while (run) {
+						MappingTask task;
+						bool has_task = false;
+						{  // locking  scope to free mutex before end of function
+							std::unique_lock<std::mutex> lock(this->queueMutex);
+							// wait for job in queue arrives
+							this->queueHasNewJob.wait(lock, [this](){
+								// predicate to check if wait can be stopped
+								// if the queue has a size or the thread should be stopped waiting ends
+								return this->queue.size() || this->stopThread;
+							});
+							if (this->stopThread) {
+								// stop the infinite while loop and proceed to let the thread stop
+								run = false;
+								return;
+							}
+							task = queue.front();
+							queue.pop_front();
+							has_task = true;
+						}
+						if (has_task) {
+							// this is intentionally not run insire locking scope of the queue
+							task.function(task.vertices);
+						}
+					}
+				});
+			}
+
+			~MappingThread(){
+				stop();
+			}
+
+			bool addTask(const MappingTask& task, const bool& replaceLatestIfFull = false) {
+				std::lock_guard<std::mutex> lock(queueMutex);
+				if (queue.size() >= maxQueueSize) {
+					if (replaceLatestIfFull) {
+						queue.pop_back();
+					}else{
+						return false;
+					}
+				}
+				queue.push_back(task);
+				queueHasNewJob.notify_one();
+				return true;
+			}
+
+			void stop() {
+				stopThread = true;
+				queueHasNewJob.notify_all();
+				thread.join();
+			}
+
+			private:
+				std::deque<MappingTask> queue;
+				std::mutex queueMutex;
+				std::condition_variable queueHasNewJob;
+
+				std::thread thread;
+				std::atomic<bool> stopThread;
+				size_t maxQueueSize;
+
+		};
+
 
 		// Operations
 		virtual bool generate_cloud();
@@ -59,8 +140,8 @@ namespace slam3d
 		boost::shared_mutex mGraphMutex;
 		boost::shared_mutex mMapMutex;
 		
-		boost::thread cloudThread;
-		boost::thread mapThread;
+		MappingThread pointcloudThread;
+		MappingThread mapThread;
 
 		int mScansAdded;
 		int mScansReceived; 

--- a/tasks/PointcloudMapper.hpp
+++ b/tasks/PointcloudMapper.hpp
@@ -9,6 +9,7 @@
 
 #include <queue>
 #include <boost/thread/shared_mutex.hpp>
+#include <boost/thread.hpp>
 
 #include "GridConfiguration.hpp"
 
@@ -58,6 +59,9 @@ namespace slam3d
 		boost::shared_mutex mGraphMutex;
 		boost::shared_mutex mMapMutex;
 		
+		boost::thread cloudThread;
+		boost::thread mapThread;
+
 		int mScansAdded;
 		int mScansReceived; 
 		bool mForceAdd;

--- a/tasks/PointcloudMapper.hpp
+++ b/tasks/PointcloudMapper.hpp
@@ -7,15 +7,11 @@
 
 #include <maps/grid/MLSMap.hpp>
 
-#include <deque>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread.hpp>
 
-#include <thread>
-#include <functional>
-#include <future>
-
 #include "GridConfiguration.hpp"
+#include "ThreadedFunctionQueue.hpp"
 
 namespace slam3d
 {	
@@ -26,82 +22,19 @@ namespace slam3d
 	friend class PointcloudMapperBase;
 	protected:
 
-
-		class MappingThread {
+		class MappingTask : public ThreadedFunctionQueue::Function {
 		 public:
-			struct MappingTask {
-				MappingTask(){};
-				MappingTask(std::function<void(VertexObjectList vertices)> function, VertexObjectList vertices ):function(function),vertices(vertices) {}
-				std::function<void(VertexObjectList vertices)> function;
-				VertexObjectList vertices;
-			};
-
-			MappingThread(size_t maxQueueSize = 1):maxQueueSize(maxQueueSize) {
-				thread = std::thread([&](){
-					bool run = true;
-					while (run) {
-						MappingTask task;
-						bool has_task = false;
-						{  // locking  scope to free mutex before end of function
-							std::unique_lock<std::mutex> lock(this->queueMutex);
-							// wait for job in queue arrives
-							this->queueHasNewJob.wait(lock, [this](){
-								// predicate to check if wait can be stopped
-								// if the queue has a size or the thread should be stopped waiting ends
-								return this->queue.size() || this->stopThread;
-							});
-							if (this->stopThread) {
-								// stop the infinite while loop and proceed to let the thread stop
-								run = false;
-								return;
-							}
-							task = queue.front();
-							queue.pop_front();
-							has_task = true;
-						}
-						if (has_task) {
-							// this is intentionally not run insire locking scope of the queue
-							task.function(task.vertices);
-						}
-					}
-				});
+			MappingTask():Function(){};
+			MappingTask(std::function<void(VertexObjectList vertices)> function, VertexObjectList vertices):Function(),function(function),vertices(vertices) {}
+			void run() override {
+				function(vertices);
 			}
-
-			~MappingThread(){
-				stop();
-			}
-
-			bool addTask(const MappingTask& task, const bool& replaceLatestIfFull = false) {
-				std::lock_guard<std::mutex> lock(queueMutex);
-				if (queue.size() >= maxQueueSize) {
-					if (replaceLatestIfFull) {
-						queue.pop_back();
-					}else{
-						return false;
-					}
-				}
-				queue.push_back(task);
-				queueHasNewJob.notify_one();
-				return true;
-			}
-
-			void stop() {
-				stopThread = true;
-				queueHasNewJob.notify_all();
-				thread.join();
-			}
-
-			private:
-				std::deque<MappingTask> queue;
-				std::mutex queueMutex;
-				std::condition_variable queueHasNewJob;
-
-				std::thread thread;
-				std::atomic<bool> stopThread;
-				size_t maxQueueSize;
-
+		 private:
+			std::function<void(VertexObjectList vertices)> function;
+			VertexObjectList vertices;
 		};
 
+		
 
 		// Operations
 		virtual bool generate_cloud();
@@ -140,8 +73,8 @@ namespace slam3d
 		boost::shared_mutex mGraphMutex;
 		boost::shared_mutex mMapMutex;
 		
-		MappingThread pointcloudThread;
-		MappingThread mapThread;
+		ThreadedFunctionQueue pointcloudThread;
+		ThreadedFunctionQueue mapThread;
 
 		int mScansAdded;
 		int mScansReceived; 

--- a/tasks/ThreadedFunctionQueue.cpp
+++ b/tasks/ThreadedFunctionQueue.cpp
@@ -1,0 +1,58 @@
+#include "ThreadedFunctionQueue.hpp"
+
+ThreadedFunctionQueue::ThreadedFunctionQueue(size_t maxQueueSize):maxQueueSize(maxQueueSize) {
+    thread = std::thread([&](){
+        bool run = true;
+        while (run) {
+            std::shared_ptr<Function> function;
+            bool has_function = false;
+            {  // locking  scope to free mutex before end of function
+                std::unique_lock<std::mutex> lock(this->queueMutex);
+                // wait for job in queue arrives
+                this->queueHasNewJob.wait(lock, [this](){
+                    // predicate to check if wait can be stopped
+                    // if the queue has a size or the thread should be stopped waiting ends
+                    // only runs when queueHasNewJob.notify_* is called
+                    return this->queue.size() || this->stopThread;
+                });
+                if (this->stopThread) {
+                    // stop the infinite while loop and proceed to let the thread stop
+                    run = false;
+                    return;
+                }
+                function = queue.front();
+                queue.pop_front();
+                has_function = true;
+            }
+            if (has_function) {
+                // this is intentionally not run insire locking scope of the queue
+                function->run();
+                function->setProcessed();
+            }
+        }
+    });
+}
+
+ThreadedFunctionQueue::~ThreadedFunctionQueue(){
+    stop();
+}
+
+bool ThreadedFunctionQueue::addFunctionCall(std::shared_ptr<Function> function, const bool& replaceLatestIfFull) {
+    std::lock_guard<std::mutex> lock(queueMutex);
+    if (queue.size() >= maxQueueSize) {  // should never be > but anyways...
+        if (replaceLatestIfFull) {
+            queue.pop_back();
+        }else{
+            return false;
+        }
+    }
+    queue.push_back(function);
+    queueHasNewJob.notify_one();
+    return true;
+}
+
+void ThreadedFunctionQueue::stop() {
+    stopThread = true;
+    queueHasNewJob.notify_all();
+    thread.join();
+}

--- a/tasks/ThreadedFunctionQueue.hpp
+++ b/tasks/ThreadedFunctionQueue.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <thread>
+#include <functional>
+#include <future>
+#include <memory>
+#include <atomic>
+#include <deque>
+
+
+/**
+ * @brief Thread that allows to add arbitrary function calls to a queue be executed by the thread
+ * 
+ * The function call needs to be wrapped into the ThreadedFunctionQueue::Function class
+ * This allows to add any type of function with paramaters, even mixed calls, to the queue.
+ * 
+ * Here is an example implementation for calling a class function with paramaters:
+ * WARNING: the parameters for the function need to be copied to the class
+ * 
+ * 		class MappingTask : public ThreadedFunctionQueue::Function {
+		 public:
+			MappingTask():Function(){};
+			MappingTask(std::function<void(VertexObjectList vertices)> function, VertexObjectList vertices):Function(),function(function),vertices(vertices) {}
+			void run() override {
+				function(vertices);
+			}
+		 private:
+			std::function<void(VertexObjectList vertices)> function;
+			VertexObjectList vertices;
+		};
+ *
+ * you can add your Function implementation by adding the shared_ptr directly (it is automatically casted)
+  	std::shared_ptr<MappingTask> task = std::make_shared<MappingTask>(std::bind(&PointcloudMapper::sendPointcloud, this, std::placeholders::_1), vertices);
+	mapThread.addFunctionCall(task, true);
+ *
+ * You can also keep your the shared_ptr<MappingTask> and use it for return values (to be set in the run() function)
+ * isProcessed() will return true after the run() function was called anf is finished by the thread
+ *
+ */
+class ThreadedFunctionQueue {
+ public:
+
+    /**
+     * @brief base Function to be implemented for adding calls to the Thread
+     */
+    class Function {
+     public:
+        Function():finished(false){}
+
+        virtual void run() = 0;
+
+        bool isProcessed() {
+            return finished;
+        }
+
+     protected:
+        friend class ThreadedFunctionQueue;
+        void setProcessed() {
+            finished = true;
+        }
+     private:
+        std::atomic<bool> finished;
+    };
+
+    /**
+     * @brief Construct a new Threaded Function Queue object
+     * 
+     * @param maxQueueSize set the maximum queue size
+     * 
+     * default: just have one pending task in addition to the currently running task (when the function calculates some result, 
+     * you want to have one additional update call with the latest data afer the running calculation (on older data) finishes).
+     * Use replaceLatestIfFull = true for calling addFunctionCall to get this behavior
+     */
+    ThreadedFunctionQueue(size_t maxQueueSize = 1);
+    
+    ~ThreadedFunctionQueue();
+
+    /**
+     * @brief add a Function call to the queue to be called by the thread
+     * 
+     * @param function shared ptr to your child class of Function (will be auto-casted) shared_ptr<MyFunctionClass>
+     * @param replaceLatestIfFull if true, the last entry will be replaced if queue is full
+     * @return true if the Function was added to the queue
+     * @return false if the Function was not added to the queue (queue full and no replace)
+     */
+    bool addFunctionCall(std::shared_ptr<Function> function, const bool& replaceLatestIfFull = false);
+
+    /**
+     * @brief stops the thread (you might not want to call this)
+     */
+    void stop();
+
+ private:
+    std::deque<std::shared_ptr<Function>> queue;
+    std::mutex queueMutex;
+    std::condition_variable queueHasNewJob;
+
+    std::thread thread;
+    std::atomic<bool> stopThread;
+    size_t maxQueueSize;
+
+};


### PR DESCRIPTION
When building the map takes a long time, it can happen that the map_publish_rate paramater triggers a new map generation in the middle of a previous map generation, calling clearMap(); while the first map generation is still running. This results in an incomplete map, which is replaced in the second run.

This PR adds some thread handling, which skips generation when the previous thead is still running